### PR TITLE
Overhaul packaging, linting, dependencies

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,48 +10,31 @@ on:
 
 jobs:
   tests:
-
     runs-on: ubuntu-latest
 
     steps:
     - name: Clone this repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
-    - name: Clone oresat-configs repository
-      uses: actions/checkout@v2
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
       with:
-        repository: oresat/oresat-configs
-        path: resources/oresat-configs
-
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.9"
-
-    - name: Build and install oresat-configs
-      working-directory: resources/oresat-configs
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        python -m build
-        pip install dist/*.whl
-
-    - name: Clean up oresat-configs
-      run: rm -rf resources/oresat-configs
+        python-version: "3.10"
+        cache: "pip"
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install .[dev]
 
-    - name: Lint with Pylama
-      run: pylama
+    - name: Check format with Ruff
+      run: ruff format --check --diff .
 
-    - name: Check format with Black
-      run: black --check --diff .
+    - name: Lint with Ruff
+      run: ruff check
 
-    - name: Check format with isort
-      run: isort --check --diff .
+    - name: Typecheck with mypy
+      run: mypy oresat_gps
 
     - name: Test building pypi package
       run: python -m build

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[dev]
+        pip install . --group dev
 
     - name: Check format with Ruff
       run: ruff format --check --diff .

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Framework), which it built ontop of [CANopen for Python]. See the
 Install dependenies
 
 ```bash
-$ pip3 install -r requirements.txt
+$ pip3 install .[dev]
 ```
 Make a virtual CAN bus
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Framework), which it built ontop of [CANopen for Python]. See the
 Install dependenies
 
 ```bash
-$ pip3 install .[dev]
+$ pip3 install . --group dev
 ```
 Make a virtual CAN bus
 

--- a/oresat_gps/__init__.py
+++ b/oresat_gps/__init__.py
@@ -1,6 +1,8 @@
-"""GPS OLAF app"""
+"""GPS OLAF app."""
 
 try:
-    from ._version import version as __version__  # type: ignore
+    from ._version import version as __version__
 except ImportError:
     __version__ = "0.0.0"  # package is not installed
+
+__all__ = ["__version__"]

--- a/oresat_gps/__main__.py
+++ b/oresat_gps/__main__.py
@@ -1,34 +1,44 @@
-"""GPS OLAF app main"""
+"""GPS OLAF app main."""
 
-import os
+from importlib.resources import files
+from pathlib import Path
 
-from olaf import app, olaf_run, olaf_setup, render_olaf_template, rest_api
+from olaf import app, logger, olaf_run, olaf_setup, render_olaf_template, rest_api
 
 from . import __version__
 from .gps_service import GpsService
+from .skytraq import MockSkyTraq, SkyTraq, SkyTraq10, SkyTraq11
 
 
 @rest_api.app.route("/skytraq")
-def skytraq_template():
+def skytraq_template() -> str:
     """Render skytraq webpage."""
-
     return render_olaf_template("skytraq.html", name="SkyTraq")
 
 
-def main():
-    """GPS OLAF app main"""
-
-    path = os.path.dirname(os.path.abspath(__file__))
-
+def main() -> None:
+    """GPS OLAF app main."""
     args, _ = olaf_setup("gps")
     mock_args = [i.lower() for i in args.mock_hw]
     mock_skytraq = "skytraq" in mock_args or "all" in mock_args
 
     app.od["versions"]["sw_version"].value = __version__
+    hw_version = app.od["versions"]["hw_version"].value
 
-    app.add_service(GpsService(app.node, mock_skytraq))
+    if mock_skytraq:
+        skytraq: SkyTraq = MockSkyTraq()
+    elif hw_version == "1.0":
+        skytraq = SkyTraq10(Path("/dev/ttyS2"))
+    elif hw_version == "1.1":
+        skytraq = SkyTraq11(Path("/dev/ttyS2"))
+    else:
+        logger.error("Invalid gps board version")
+        # attempt the latest anyway
+        skytraq = SkyTraq11(Path("/dev/ttyS2"))
 
-    rest_api.add_template(f"{path}/templates/skytraq.html")
+    app.add_service(GpsService(skytraq))
+
+    rest_api.add_template(files('oresat_gps') / 'templates' / 'skytraq.html')
 
     olaf_run()
 

--- a/oresat_gps/gps_service.py
+++ b/oresat_gps/gps_service.py
@@ -1,21 +1,20 @@
-"""
-GPS SkyTraq Service.
+"""GPS SkyTraq Service.
 
 Reads the GPS data stream from SkyTraq and puts the data into the OD.
 """
 
-from datetime import datetime
-from enum import IntEnum
+from datetime import datetime, timezone
+from enum import Enum, unique
 from os import geteuid
 from time import CLOCK_REALTIME, clock_settime
 
-import canopen
-from olaf import Gpio, NetworkError, Node, Service, logger
+from olaf import NetworkError, Service, logger
 
 from .skytraq import FixMode, SkyTraq, SkyTraqError, gps_datetime
 
 
-class GpsState(IntEnum):
+@unique
+class GpsState(Enum):
     """SkyTraq GPS State."""
 
     OFF = 0x00
@@ -27,26 +26,15 @@ class GpsState(IntEnum):
 class GpsService(Service):
     """GPS SkyTraq Service."""
 
-    def __init__(self, node: Node, mock_hw: bool = False):
+    def __init__(self, gps: SkyTraq) -> None:
         super().__init__()
-
-        self._skytraq = SkyTraq("/dev/ttyS2", mock_hw)
-        self._hw_version_obj = node.od["versions"]["hw_version"]
-        if self._hw_version_obj.value == "1.0":
-            self._gpio_skytraq = Gpio("STQ_EN", mock_hw)
-            self._gpio_lna = Gpio("MAX_EN", mock_hw)
-        elif self._hw_version_obj.value == "1.1":
-            self._gpio_en = Gpio("GPS_EN", mock_hw)
-
+        self._skytraq = gps
         self._state = GpsState.OFF
 
-        self._uid = geteuid()
-        if self._uid != 0:
+        if geteuid() != 0:
             logger.warning("not running as root, cannot set system time to time from skytraq")
 
-        self.is_syncd_obj: canopen.objectdictionary.Variable = None
-
-    def on_start(self):
+    def on_start(self) -> None:
         self.node.add_sdo_callbacks("status", None, self._on_read, self._on_write)
 
         self.is_syncd_obj = self.node.od["time_syncd"]
@@ -55,21 +43,21 @@ class GpsService(Service):
 
         self._skytraq_power_on()
 
-    def on_stop(self):
+    def on_stop(self) -> None:
         self._skytraq_power_off()
 
-    def _on_read(self):
+    def _on_read(self) -> int:
         return self._state.value
 
-    def _on_write(self, value):
+    def _on_write(self, value: int) -> None:
         # turn skytraq on/off
         if value:
             self._skytraq_power_on()
         else:
             self._skytraq_power_off()
 
-    def on_loop(self):
-        if not self._skytraq.is_conencted:
+    def on_loop(self) -> None:
+        if not self._skytraq.is_connected:
             self.sleep(0.1)
             return  # do nothing
 
@@ -83,14 +71,14 @@ class GpsService(Service):
         skytraq_rec["packet_count"].value += 1
         skytraq_rec["last_packet"].value = raw
 
-        if nav_data.fix_mode == FixMode.NO_FIX:
+        if nav_data.fix_mode == FixMode.NO_FIX.value:
             skytraq_rec["fix_mode"].value = FixMode.NO_FIX.value
         else:
             # datetime from gps message
             ts = gps_datetime(nav_data.gps_week, nav_data.tow)
 
             # sync clock if it hasn't been syncd yet
-            if not self.is_syncd_obj.value and self._uid == 0:
+            if not self.is_syncd_obj.value and geteuid() == 0:
                 clock_settime(CLOCK_REALTIME, ts)
                 logger.info("set time based off of skytraq time")
                 self.is_syncd_obj.value = True
@@ -101,7 +89,7 @@ class GpsService(Service):
                     continue
                 skytraq_rec[key].value = value
 
-            dt = datetime.fromtimestamp(ts)
+            dt = datetime.fromtimestamp(ts, tz=timezone.utc)
             ms_since_midnight = (((((dt.hour * 60) + dt.minute) * 60) + dt.second) * 1000) + (
                 dt.microsecond // 1000
             )
@@ -117,32 +105,22 @@ class GpsService(Service):
                 pass  # CAN network is down
 
         # update status
-        if nav_data.number_of_sv >= 4 and nav_data.fix_mode >= FixMode.FIX_2D:
+        if nav_data.number_of_sv >= 4 and nav_data.fix_mode >= FixMode.FIX_2D.value:
             self._state = GpsState.LOCKED
         else:
             self._state = GpsState.SEARCHING
 
-    def on_loop_error(self, error: str):
+    def on_loop_error(self, error: str) -> None:
         self._skytraq_power_off()
         self._state = GpsState.ERROR
         logger.exception(error)
 
-    def _skytraq_power_on(self):
+    def _skytraq_power_on(self) -> None:
         logger.info("turning SkyTraq on")
-        if self._hw_version_obj.value == "1.0":
-            self._gpio_skytraq.high()
-            self._gpio_lna.high()
-        elif self._hw_version_obj.value == "1.1":
-            self._gpio_en.high()
         self._skytraq.connect()
         self._state = GpsState.SEARCHING
 
-    def _skytraq_power_off(self):
+    def _skytraq_power_off(self) -> None:
         logger.info("turning SkyTraq off")
         self._skytraq.disconnect()
-        if self._hw_version_obj.value == "1.0":
-            self._gpio_lna.low()
-            self._gpio_skytraq.low()
-        elif self._hw_version_obj.value == "1.1":
-            self._gpio_en.low()
         self._state = GpsState.OFF

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "build",
     "ruff",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,25 +6,29 @@ build-backend = "setuptools.build_meta"
 name = "oresat-gps"
 description = "OreSat GPS OLAF app"
 readme = "README.md"
-requires-python = ">=3.7"
-license = {text = "GPL-3.0"}
+requires-python = ">=3.10"
+license = "GPL-3.0-or-later"
 classifiers = [
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Topic :: Software Development :: Embedded Systems",
 ]
 dependencies = [
-    "oresat-configs",
-    "oresat-olaf>=3.2.0",
+    "oresat-olaf>=3.6.5",
     "pyserial",
 ]
 dynamic = ["version"]
+
+[project.optional-dependencies]
+dev = [
+    "build",
+    "ruff",
+    "mypy",
+    "types-pyserial",
+    "pytest",
+    "pytest-cov",
+]
 
 [project.scripts]
 oresat-gps = "oresat_gps.__main__:main"
@@ -38,30 +42,41 @@ exclude = ["docs*"]
 [tool.setuptools_scm]
 write_to = "oresat_gps/_version.py"
 
-[tool.black]
-line_length = 100
+[tool.ruff]
+line-length = 100
 
-[tool.pylama]
-format = "pylint"
-skip = "*/.tox/*,*/.env/,*/.git/*,*/.github/*,*/build/*"
-linters = "pycodestyle,pyflakes,pylint,mccabe,mypy,radon"
-# C0103:    Arguments are not snake_case naming style or too short
-# E203:     Whitespace before ':' (black does this)
-# W0613:    Unused argument
-# R0902:    Too many instance attributes
-# R901:     Too complex
-# R0913:    Too many arguments
-# R0914:    Too many local variables
-# W1514:    Using open without explicitly specifying an encoding
-# W0707:    Consider explicitly re-raising
-# C901:     Function is too complex
-ignore = "C0103,E203,W0613,R0902,R901,R0913,R0914,W1514,W0707,C901"
-max_line_length = 100
+[tool.ruff.format]
+quote-style = "preserve"
+
+[tool.ruff.lint]
+select = ["ALL"]
+ignore = [
+    # D203 and D213 conflict with D211 and D212. Prefer the latter which follow
+    # PEP257
+    "D203",
+    "D213",
+    # Conflicts with formatter
+    "COM812", # missing-trailing-comma
+    # Stylistic choices for quote-style = preserve
+    "Q000",  # Single quotes found but double quotes preferred
+    "Q002",  # Single quote docstring found but double quotes preferred
+    "D300",  # Use triple double quotes
+    # FIXME: These should be turned back on but take effort
+    "D102",  # Missing docstring in public method
+    "D107",  # Missing docstring in `__init__`
+    # These are the opposite of what I want
+    "D413",  # Missing blank line after last section
+    "EM101", # Exception must not use a string literal
+    "EM102", # Exception must not use an f-string literal
+    "FIX",  # flake8-fixme
+    "TD",  # flake8-todos
+    # This might be good to turn on later, right now I'm on the fence about it
+    "TRY003",  # Avoid specifying long messages outside the exception class
+    # Another one that might be good later but for now is too argessive. Many of
+    # the numbers it flags are obvious from context.
+    "PLR2004",  # Magic value used in comparison
+]
 
 [[tool.mypy.overrides]]
-module = "canopen,olaf,serial,oresat_configs"
+module = "olaf"
 ignore_missing_imports = true
-
-[tool.isort]
-profile = "black"
-line_length = 100

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-black
-build
-isort
-oresat-olaf>=3.3.1
-pylama
-pyserial
-setuptools
-setuptools-scm


### PR DESCRIPTION
This migrates this project to a fully pyproject.toml based project following current best practices. Linting, formatting, and typechecking have been replaced with Ruff and mypy, as Ruff is currently the only really well maintained linter/formatter.

I've also fixed the lints and formatting recommended as well as added type hints where required for mypy --strict. It nearly fully passes except for needing olaf to also be type annotated.

This does make two behavioral changes, I've split SkyTraq into 4 classes, a base, one for both of the boards (1.0, 1.1), and a mock version. The board specific versions now have control over their GPIO pins instead of the service since the class manages the hardware.

The second change is removing the custom readline() behavior. It was confusing the length argument for a timeout. This may have been one of the issues with reading things from the SkyTraq.