### PR TITLE
Add SkyTraq binary message encoder

### DIFF
--- a/oresat_gps/skytraq.py
+++ b/oresat_gps/skytraq.py
@@ -6,13 +6,14 @@ from functools import reduce
 from operator import xor
 from pathlib import Path
 from time import sleep
-from typing import TYPE_CHECKING, NamedTuple, Union
+from typing import Iterable, TYPE_CHECKING, NamedTuple
 
 if TYPE_CHECKING:
     import gpiod
 
 from gpiod.line import Value
 from serial import Serial, SerialException
+
 
 class NavData(NamedTuple):
     '''Raw Navigation data returned from a SkyTraq.'''
@@ -151,11 +152,11 @@ class SkyTraq:
         return nav_data, payload_bytes
 
     @staticmethod
-    def checksum(payload: bytes) -> int:
+    def checksum(payload: Iterable[int]) -> int:
         return reduce(xor, payload, 0)
 
     @classmethod
-    def encode_binary(cls, message_id: int, body: Union[bytes, str]) -> bytes:
+    def encode_binary(cls, message_id: int, body: bytes) -> bytes:
         """Encode a message ID and body into a SkyTraq binary message.
 
         Parameters
@@ -163,7 +164,7 @@ class SkyTraq:
         message_id
             The message ID.
         body
-            The message body. Can be a bytestring or hex string
+            The message body.
 
         Returns
         -------
@@ -176,20 +177,14 @@ class SkyTraq:
             If message_id > 1 byte or body > 65534 bytes. SkyTraq limits total
             payload size to 65535 bytes (id + body).
         """
-        if type(body) is str:
-            if body.startswith("0x"):
-                body = body.split("0x")[1]
-            num: int = int(body, 16)
-            byte_length: int = len(body) // 2
-            body = num.to_bytes(byte_length)
-
-        msg_bytes: bytes = message_id.to_bytes(1)
-        payload_length: bytes = (1 + len(body)).to_bytes(2)
+        msg_bytes: bytes = message_id.to_bytes(1, byteorder="big")
+        payload_length: bytes = (1 + len(body)).to_bytes(2, byteorder="big")
         payload_bytes: bytearray = bytearray(msg_bytes)
-        payload_bytes.extend(body)
+        payload_bytes += body
+        cs: bytes = cls.checksum(payload_bytes).to_bytes(1, byteorder="big")
         # <0xA0,0xA1><PL><Message ID><Message Body><CS><0x0D,0x0A>
         payload_bytes[0:0] = cls.BINARY_START + payload_length
-        payload_bytes.extend(cls.checksum(payload_bytes).to_bytes() + SkyTraq.BINARY_END)
+        payload_bytes += cs + cls.BINARY_END
         return bytes(payload_bytes)
 
     def connect(self) -> None:

--- a/oresat_gps/skytraq.py
+++ b/oresat_gps/skytraq.py
@@ -75,7 +75,6 @@ class SkyTraq:
     CS := 0x0b ^ 0x00 = 0x0b
     """
 
-    BINARY_MODE = b"\xa0\xa1\x00\x03\x09\x02\x00\x0b\x0d\x0a"
     """Command to swap to binary mode"""
     BINARY_START: bytes = b'\xA0\xA1'
     """SkyTraq binary message start bytes"""
@@ -87,8 +86,8 @@ class SkyTraq:
     def __init__(self, port: Path) -> None:
         """Create a SkyTraq instance associated with a specific serial interface.
 
-        Paramters
-        ---------
+        Parameters
+        ----------
         port
                 Serial port to use.
         """
@@ -107,7 +106,7 @@ class SkyTraq:
         Raises
         ------
         SkyTraqError
-            An error occured.
+            An error occurred.
 
         Returns
         -------
@@ -190,7 +189,7 @@ class SkyTraq:
     def connect(self) -> None:
         """Connect to the Skytraq receiver serial interface."""
         self._ser = Serial(str(self._port), self.BAUD, timeout=1)
-        self._ser.write(self.BINARY_MODE)  # swap to binary mode
+        self._ser.write(SkyTraq.encode_binary(0x09, b"\x02\x00"))  # swap to binary mode
 
     def disconnect(self) -> None:
         """Disconnect from the Skytraq receiver serial interface."""

--- a/oresat_gps/skytraq.py
+++ b/oresat_gps/skytraq.py
@@ -14,13 +14,6 @@ if TYPE_CHECKING:
 from gpiod.line import Value
 from serial import Serial, SerialException
 
-from oresat_gps._gpio import request_gpio_output
-
-BINARY_START: bytes = b'\xA0\xA1'
-"""SkyTraq binary message start bytes"""
-BINARY_END: bytes = b'\x0D\x0A'
-"""SkyTraq binary message end bytes"""
-
 class NavData(NamedTuple):
     '''Raw Navigation data returned from a SkyTraq.'''
 
@@ -82,6 +75,12 @@ class SkyTraq:
     """
 
     BINARY_MODE = b"\xa0\xa1\x00\x03\x09\x02\x00\x0b\x0d\x0a"
+    """Command to swap to binary mode"""
+    BINARY_START: bytes = b'\xA0\xA1'
+    """SkyTraq binary message start bytes"""
+    BINARY_END: bytes = b'\x0D\x0A'
+    """SkyTraq binary message end bytes"""
+
     BAUD = 115200
 
     def __init__(self, port: Path) -> None:
@@ -141,7 +140,7 @@ class SkyTraq:
         if len(payload_bytes) != pl:
             raise SkyTraqError(f"payload length does not match {len(payload_bytes)} vs {pl}")
 
-        if reduce(xor, payload_bytes, 0) != checksum_byte:
+        if self.checksum(payload_bytes) != checksum_byte:
             raise SkyTraqError("invalid checksum")
 
         try:
@@ -152,9 +151,12 @@ class SkyTraq:
         return nav_data, payload_bytes
 
     @staticmethod
-    def encode_binary(message_id: int, body: Union[bytes, str]) -> bytes:
-        """
-        Encode a message ID and body into a SkyTraq binary message.
+    def checksum(payload: bytes) -> int:
+        return reduce(xor, payload, 0)
+
+    @classmethod
+    def encode_binary(cls, message_id: int, body: Union[bytes, str]) -> bytes:
+        """Encode a message ID and body into a SkyTraq binary message.
 
         Parameters
         ----------
@@ -185,13 +187,9 @@ class SkyTraq:
         payload_length: bytes = (1 + len(body)).to_bytes(2)
         payload_bytes: bytearray = bytearray(msg_bytes)
         payload_bytes.extend(body)
-        # checksum gen
-        cs: int = 0
-        for n in payload_bytes:
-            cs ^= n
         # <0xA0,0xA1><PL><Message ID><Message Body><CS><0x0D,0x0A>
-        payload_bytes[0:0] = BINARY_START + payload_length
-        payload_bytes.extend(cs.to_bytes() + BINARY_END)
+        payload_bytes[0:0] = cls.BINARY_START + payload_length
+        payload_bytes.extend(cls.checksum(payload_bytes).to_bytes() + SkyTraq.BINARY_END)
         return bytes(payload_bytes)
 
     def connect(self) -> None:

--- a/oresat_gps/skytraq.py
+++ b/oresat_gps/skytraq.py
@@ -1,18 +1,21 @@
 """SkyTraq serial driver."""
 
 import struct
+from collections.abc import Iterable
 from enum import Enum, unique
 from functools import reduce
 from operator import xor
 from pathlib import Path
 from time import sleep
-from typing import Iterable, TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 if TYPE_CHECKING:
     import gpiod
 
 from gpiod.line import Value
 from serial import Serial, SerialException
+
+from oresat_gps._gpio import request_gpio_output
 
 
 class NavData(NamedTuple):
@@ -75,10 +78,9 @@ class SkyTraq:
     CS := 0x0b ^ 0x00 = 0x0b
     """
 
-    """Command to swap to binary mode"""
-    BINARY_START: bytes = b'\xA0\xA1'
+    BINARY_START: bytes = b'\xa0\xa1'
     """SkyTraq binary message start bytes"""
-    BINARY_END: bytes = b'\x0D\x0A'
+    BINARY_END: bytes = b'\x0d\x0a'
     """SkyTraq binary message end bytes"""
 
     BAUD = 115200
@@ -189,7 +191,8 @@ class SkyTraq:
     def connect(self) -> None:
         """Connect to the Skytraq receiver serial interface."""
         self._ser = Serial(str(self._port), self.BAUD, timeout=1)
-        self._ser.write(SkyTraq.encode_binary(0x09, b"\x02\x00"))  # swap to binary mode
+        # swap to binary mode
+        self._ser.write(SkyTraq.encode_binary(0x09, b"\x02\x00"))
 
     def disconnect(self) -> None:
         """Disconnect from the Skytraq receiver serial interface."""

--- a/oresat_gps/skytraq.py
+++ b/oresat_gps/skytraq.py
@@ -6,7 +6,7 @@ from functools import reduce
 from operator import xor
 from pathlib import Path
 from time import sleep
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple, Union
 
 if TYPE_CHECKING:
     import gpiod
@@ -16,6 +16,10 @@ from serial import Serial, SerialException
 
 from oresat_gps._gpio import request_gpio_output
 
+BINARY_START: bytes = b'\xA0\xA1'
+"""SkyTraq binary message start bytes"""
+BINARY_END: bytes = b'\x0D\x0A'
+"""SkyTraq binary message end bytes"""
 
 class NavData(NamedTuple):
     '''Raw Navigation data returned from a SkyTraq.'''
@@ -146,6 +150,49 @@ class SkyTraq:
             raise SkyTraqError("Error unpacking payload") from e
 
         return nav_data, payload_bytes
+
+    @staticmethod
+    def encode_binary(message_id: int, body: Union[bytes, str]) -> bytes:
+        """
+        Encode a message ID and body into a SkyTraq binary message.
+
+        Parameters
+        ----------
+        message_id
+            The message ID.
+        body
+            The message body. Can be a bytestring or hex string
+
+        Returns
+        -------
+        bytes
+            The encoded message.
+
+        Raises
+        ------
+        OverflowError
+            If message_id > 1 byte or body > 65534 bytes. SkyTraq limits total
+            payload size to 65535 bytes (id + body).
+        """
+        if type(body) is str:
+            if body.startswith("0x"):
+                body = body.split("0x")[1]
+            num: int = int(body, 16)
+            byte_length: int = len(body) // 2
+            body = num.to_bytes(byte_length)
+
+        msg_bytes: bytes = message_id.to_bytes(1)
+        payload_length: bytes = (1 + len(body)).to_bytes(2)
+        payload_bytes: bytearray = bytearray(msg_bytes)
+        payload_bytes.extend(body)
+        # checksum gen
+        cs: int = 0
+        for n in payload_bytes:
+            cs ^= n
+        # <0xA0,0xA1><PL><Message ID><Message Body><CS><0x0D,0x0A>
+        payload_bytes[0:0] = BINARY_START + payload_length
+        payload_bytes.extend(cs.to_bytes() + BINARY_END)
+        return bytes(payload_bytes)
 
     def connect(self) -> None:
         """Connect to the Skytraq receiver serial interface."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,10 @@ ignore = [
     "PLR2004",  # Magic value used in comparison
 ]
 
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["S101"]
+
+
 [[tool.mypy.overrides]]
 module = "olaf"
 ignore_missing_imports = true

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for oresat-gps."""

--- a/tests/test_skytraq.py
+++ b/tests/test_skytraq.py
@@ -1,0 +1,9 @@
+from oresat_gps.skytraq import SkyTraq
+
+
+def test_checksum() -> None:
+    assert SkyTraq.checksum(b"\x09\x02\x00") == 11
+
+def test_encode_binary() -> None:
+    # binary mode message
+    assert SkyTraq.encode_binary(0x09, b"\x02\x00") == b"\xa0\xa1\x00\x03\x09\x02\x00\x0b\x0d\x0a"

--- a/tests/test_skytraq.py
+++ b/tests/test_skytraq.py
@@ -4,6 +4,7 @@ from oresat_gps.skytraq import SkyTraq
 def test_checksum() -> None:
     assert SkyTraq.checksum(b"\x09\x02\x00") == 11
 
+
 def test_encode_binary() -> None:
     # binary mode message
     assert SkyTraq.encode_binary(0x09, b"\x02\x00") == b"\xa0\xa1\x00\x03\x09\x02\x00\x0b\x0d\x0a"

--- a/tests/test_skytraq.py
+++ b/tests/test_skytraq.py
@@ -1,10 +1,14 @@
+"""Tests for the SkyTraq module."""
+
 from oresat_gps.skytraq import SkyTraq
 
 
 def test_checksum() -> None:
+    """Test the checksum method. Uses the body from a binary mode message."""
     assert SkyTraq.checksum(b"\x09\x02\x00") == 11
 
 
 def test_encode_binary() -> None:
+    """Test the checksum method. Uses the body from a binary mode message."""
     # binary mode message
     assert SkyTraq.encode_binary(0x09, b"\x02\x00") == b"\xa0\xa1\x00\x03\x09\x02\x00\x0b\x0d\x0a"


### PR DESCRIPTION
This PR adds a simple binary encoding method for the SkyTraq format. The binary mode enable message is packed using the new method. Includes basic unit tests.