### PR TITLE
Serial reader rewrite

### DIFF
--- a/oresat_gps/gps_service.py
+++ b/oresat_gps/gps_service.py
@@ -126,7 +126,12 @@ class GpsService(Service):
 
     def _skytraq_power_on(self) -> None:
         logger.info("turning SkyTraq on")
-        self._skytraq.connect()
+        try:
+            self._skytraq.connect()
+        except SkyTraqError as e:
+            logger.error("Error connecting to SkyTraq: %s", e)
+            self._skytraq.disconnect()
+            return
         self._state = GpsState.SEARCHING
 
     def _skytraq_power_off(self) -> None:

--- a/oresat_gps/skytraq.py
+++ b/oresat_gps/skytraq.py
@@ -83,6 +83,8 @@ class SkyTraq:
     """SkyTraq binary message start bytes"""
     BINARY_END: bytes = b'\x0d\x0a'
     """SkyTraq binary message end bytes"""
+    MSG_ID_ACK = 0x83
+    MSG_ID_NACK = 0x84
 
     BAUD = 115200
 
@@ -95,6 +97,44 @@ class SkyTraq:
                 Serial port to use.
         """
         self._port = port
+
+    def _check_for_ack(self, expected_msg_id: int, read_count: int = 10) -> bool:
+        """Read and check for ACK/NACK.
+
+        This is called after sending a command.
+
+        Parameters
+        ----------
+        expected_msg_id
+            The expected message ID for the previously sent message.
+        read_count
+            The number of attempts to look for ACK/NACK.
+
+        Returns
+        -------
+        bool
+            True for ACK, False for NACK.
+
+        Raises
+        ------
+        SkyTraqError
+            Incorrect or missing ACK or NACK
+        """
+        for _ in range(read_count):
+            raw = self._read()
+            try:
+                payload = self.decode_binary(raw)
+            except ValueError:
+                continue
+            msg_id = payload[0]
+            if msg_id == self.MSG_ID_ACK:
+                if payload[1] != expected_msg_id:
+                    raise SkyTraqError("ACK for wrong message: {payload[1]:#x")
+                return True
+            if msg_id == self.MSG_ID_NACK:
+                logger.warning("NACK for %#x", expected_msg_id)
+                return False
+        raise SkyTraqError("No ACK or NACK received")
 
     def _read(self) -> bytes:
         r"""Read from skytraq serial interface.
@@ -209,10 +249,19 @@ class SkyTraq:
         return payload
 
     def connect(self) -> None:
-        """Connect to the Skytraq receiver serial interface."""
+        """Connect to the Skytraq receiver serial interface.
+
+        Raises
+        ------
+        SkyTraqError
+            Error initializing the SkyTraq
+        """
         self._ser = Serial(str(self._port), self.BAUD, timeout=1)
         # swap to binary mode
         self._ser.write(SkyTraq.encode_binary(0x09, b"\x02\x00"))
+        if not self._check_for_ack(0x09):
+            logger.error("No ACK for Binary mode")
+            raise SkyTraqError("Binary mode not acknowledged")
 
     def disconnect(self) -> None:
         """Disconnect from the Skytraq receiver serial interface."""

--- a/oresat_gps/skytraq.py
+++ b/oresat_gps/skytraq.py
@@ -122,9 +122,9 @@ class SkyTraq:
         """
         for _ in range(read_count):
             raw = self._read()
-            try:
-                payload = self.decode_binary(raw)
-            except ValueError:
+            csum = raw[-1]
+            payload = raw[:-1]
+            if csum != self.checksum(payload):
                 continue
             msg_id = payload[0]
             if msg_id == self.MSG_ID_ACK:
@@ -154,25 +154,42 @@ class SkyTraq:
         Returns
         -------
         bytes
-            The bytes from the body. The first byte is the message the rest are the payload bytes.
+            The payload bytes and checksum byte.
+
+        Raises
+        ------
+        SkyTraqError
+            An error occurred on the serial read or the packet is invalid.
         """
         try:
             self._ser.read_until(self.BINARY_START)
             payload_len_raw = self._ser.read(2)
             payload_len = int.from_bytes(payload_len_raw, byteorder="big")
             remaining = self._ser.read(payload_len + 3)
-            return self.BINARY_START + payload_len_raw + remaining
+            if remaining[-2:] != self.BINARY_END:
+                raise SkyTraqError("Invalid binary message")
+            return remaining[:-2]
         except SerialException as e:
             raise SkyTraqError("Error reading GPS line") from e
 
     def read(self) -> tuple[NavData, bytes]:
-        """Read a message from the SkyTraq."""
+        """Read a message from the SkyTraq.
+
+        Returns
+        -------
+        tuple[NavData, bytes]
+            The Navigation Data and the raw data.
+
+        Raises
+        ------
+        SkyTraqError
+            Invalid checksum or error unpacking.
+        """
         msg = self._read()
-        try:
-            payload = self.decode_binary(msg)
-        except ValueError as e:
-            logger.error("Error decoding payload: %s", e)
-            raise SkyTraqError("Error decoding payload") from e
+        csum = msg[-1]
+        payload = msg[:-1]
+        if csum != self.checksum(payload):
+            raise SkyTraqError("Invalid checksum")
 
         try:
             nav_data = NavData(*struct.unpack(">3BHI2i2I5H6i", payload))
@@ -216,37 +233,6 @@ class SkyTraq:
         payload_bytes[0:0] = cls.BINARY_START + payload_length
         payload_bytes += cs + cls.BINARY_END
         return bytes(payload_bytes)
-
-    @classmethod
-    def decode_binary(cls, data: bytes) -> bytes:
-        """Decode a SkyTraq binary message and return the payload.
-
-        Parameters
-        ----------
-        data
-            The encoded message.
-
-        Returns
-        -------
-        bytes
-            The decoded payload.
-
-        Raises
-        ------
-        ValueError
-            The message is missing its sequence start or end, or length or checksum does not match.
-        """
-        if not data[:2] == cls.BINARY_START or not data[-2:] == cls.BINARY_END:
-            raise ValueError("invalid binary message")
-        inner = data[2:-2]
-        payload_len = inner[0:2]
-        payload = inner[2:-1]
-        csum = inner[-1]
-        if struct.unpack(">H", payload_len)[0] != len(payload):
-            raise ValueError(f"payload length does not match {payload_len!r} vs {len(payload)}")
-        if csum != cls.checksum(payload):
-            raise ValueError("invalid checksum")
-        return payload
 
     def connect(self) -> None:
         """Connect to the Skytraq receiver serial interface.

--- a/oresat_gps/skytraq.py
+++ b/oresat_gps/skytraq.py
@@ -157,19 +157,19 @@ class SkyTraq:
             The bytes from the body. The first byte is the message the rest are the payload bytes.
         """
         try:
-            line = self._ser.readline()
+            self._ser.read_until(self.BINARY_START)
+            payload_len_raw = self._ser.read(2)
+            payload_len = int.from_bytes(payload_len_raw, byteorder="big")
+            remaining = self._ser.read(payload_len + 3)
+            return self.BINARY_START + payload_len_raw + remaining
         except SerialException as e:
             raise SkyTraqError("Error reading GPS line") from e
-        if not line:
-            raise SkyTraqError("skytraq serial read failed")
-        return line
 
     def read(self) -> tuple[NavData, bytes]:
-        """Read the stream of messages from the Skytraq."""
-        # See Application Note AN0037 for format
-        line = self._read()
+        """Read a message from the SkyTraq."""
+        msg = self._read()
         try:
-            payload = self.decode_binary(line)
+            payload = self.decode_binary(msg)
         except ValueError as e:
             logger.error("Error decoding payload: %s", e)
             raise SkyTraqError("Error decoding payload") from e

--- a/tests/test_skytraq.py
+++ b/tests/test_skytraq.py
@@ -1,8 +1,12 @@
 """Tests for the SkyTraq module."""
 
-import pytest
+from collections.abc import Generator
+from typing import Any
 
-from oresat_gps.skytraq import SkyTraq
+import pytest
+import serial
+
+from oresat_gps.skytraq import MockSkyTraq, NavData, SkyTraq, SkyTraqError
 
 ENCODE_CASES = [
     (0x09, b"\x02\x00", b"\xa0\xa1\x00\x03\x09\x02\x00\x0b\x0d\x0a"),
@@ -19,7 +23,7 @@ def test_checksum() -> None:
 
 
 @pytest.mark.parametrize(("msg_id", "body", "expected"), ENCODE_CASES)
-def test_encode_binary(msg_id: bytes, body: bytes, expected: bytes) -> None:
+def test_encode_binary(msg_id: int, body: bytes, expected: bytes) -> None:
     """Test the encode method."""
     assert SkyTraq.encode_binary(msg_id, body) == expected
 
@@ -29,3 +33,27 @@ def test_decode_binary(raw: bytes, expected: bytes) -> None:
     """Test the SkyTraq binary decoder."""
     payload = SkyTraq.decode_binary(raw)
     assert payload == expected
+
+
+@pytest.fixture
+def loopback_skytraq() -> Generator[SkyTraq, Any, None]:
+    """Pyserial loopback fixture."""
+    gps = SkyTraq.__new__(SkyTraq)
+    gps._ser = serial.serial_for_url("loop://", timeout=1)  # noqa: SLF001
+    yield gps
+    gps._ser.close()  # noqa: SLF001
+
+
+def test_read(loopback_skytraq: SkyTraq) -> None:
+    """Test the read method."""
+    loopback_skytraq._ser.write(MockSkyTraq.MOCK_DATA)  # noqa: SLF001
+    nav, _payload = loopback_skytraq.read()
+    assert isinstance(nav, NavData)
+
+
+def test_read_terminator_payload(loopback_skytraq: SkyTraq) -> None:
+    """Test the read method, with a payload containing a terminator."""
+    raw = SkyTraq.encode_binary(0xA8, b"\x0a" * 63)
+    loopback_skytraq._ser.write(raw)  # noqa: SLF001
+    with pytest.raises(SkyTraqError):
+        loopback_skytraq.read()

--- a/tests/test_skytraq.py
+++ b/tests/test_skytraq.py
@@ -28,13 +28,6 @@ def test_encode_binary(msg_id: int, body: bytes, expected: bytes) -> None:
     assert SkyTraq.encode_binary(msg_id, body) == expected
 
 
-@pytest.mark.parametrize(("raw", "expected"), DECODE_CASES)
-def test_decode_binary(raw: bytes, expected: bytes) -> None:
-    """Test the SkyTraq binary decoder."""
-    payload = SkyTraq.decode_binary(raw)
-    assert payload == expected
-
-
 @pytest.fixture
 def loopback_skytraq() -> Generator[SkyTraq, Any, None]:
     """Pyserial loopback fixture."""

--- a/tests/test_skytraq.py
+++ b/tests/test_skytraq.py
@@ -1,7 +1,6 @@
 """Tests for the SkyTraq module."""
 
 from collections.abc import Generator
-from typing import Any
 
 import pytest
 import serial
@@ -29,7 +28,7 @@ def test_encode_binary(msg_id: int, body: bytes, expected: bytes) -> None:
 
 
 @pytest.fixture
-def loopback_skytraq() -> Generator[SkyTraq, Any, None]:
+def loopback_skytraq() -> Generator[SkyTraq]:
     """Pyserial loopback fixture."""
     gps = SkyTraq.__new__(SkyTraq)
     gps._ser = serial.serial_for_url("loop://", timeout=1)  # noqa: SLF001


### PR DESCRIPTION
This needs #21 first, as the ACK check relies on the new decoder.

Message writes respect ACK, by attempting to read for ACK or NACK after the binary request write.

This also changes the read logic to the following flow:

1. read for the starting bytes
2. Read the two payload length bytes and get the length
3. Read the remaining bytes according to the payload length

And of course, some tests! Though this needs to be tested on a real GPS card ASAP.

Closes #18 