### PR TITLE
Add PyPI trusted publishing workflow, require OLAF v3.7.0

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -2,20 +2,20 @@ name: Upload Python Package
 
 on:
   release:
-    types: [published]
+    types: [ "published" ]
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
 
     steps:
-    - uses: actions/checkout@v3
-
-    - name: Set up Python
-      uses: actions/setup-python@v3
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
-        python-version: '3.x'
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -24,9 +24,5 @@ jobs:
     - name: Build package
       run: python -m build
 
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
-
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - name: Clone this repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python 3.10
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.10"
         cache: "pip"

--- a/oresat_gps/__init__.py
+++ b/oresat_gps/__init__.py
@@ -35,8 +35,8 @@ def main() -> None:
     mock_args = [i.lower() for i in args.mock_hw]
     mock_skytraq = "skytraq" in mock_args or "all" in mock_args
 
-    app.od["versions"]["sw_version"].value = __version__
-    hw_version = app.od["versions"]["hw_version"].value
+    app.od["versions"]["sw_version"].value = __version__  # type: ignore[index]
+    hw_version = app.od["versions"]["hw_version"].value  # type: ignore[index]
 
     if mock_skytraq:
         logger.debug("Mocking the skytraq.")
@@ -52,6 +52,6 @@ def main() -> None:
 
     app.add_service(GpsService(skytraq))
 
-    rest_api.add_template(files('oresat_gps') / 'templates' / 'skytraq.html')
+    rest_api.add_template(str(files('oresat_gps') / 'templates' / 'skytraq.html'))
 
     olaf_run()

--- a/oresat_gps/gps_service.py
+++ b/oresat_gps/gps_service.py
@@ -7,7 +7,9 @@ from datetime import datetime, timedelta, timezone
 from enum import Enum, unique
 from os import geteuid
 from time import CLOCK_REALTIME, clock_settime
+from typing import cast
 
+from canopen.objectdictionary import ODRecord, ODVariable
 from olaf import NetworkError, Service, logger
 
 from .skytraq import FixMode, SkyTraq, SkyTraqError
@@ -37,9 +39,13 @@ class GpsService(Service):
     def on_start(self) -> None:
         self.node.add_sdo_callbacks("status", None, self._on_read, self._on_write)
 
-        self.is_syncd_obj = self.node.od["time_syncd"]
+        # Dealing with the ObjectDictionary type annotations is really quite annoying, there's
+        # got to be a better way than casting my problems away.
+        self._is_syncd = cast(ODVariable, self.node.od["time_syncd"])
+        self._skytraq_rec = cast(ODRecord, self.node.od["skytraq"])
+
         # make sure the flag for the time has been syncd is set to false
-        self.is_syncd_obj.value = False
+        self._is_syncd.value = False
 
         self._skytraq_power_on()
 
@@ -67,13 +73,11 @@ class GpsService(Service):
             logger.debug(e)
             return
 
-        skytraq_rec = self.node.od["skytraq"]
-
-        skytraq_rec["packet_count"].value += 1
-        skytraq_rec["last_packet"].value = raw
+        self._skytraq_rec["packet_count"].value += 1  # type: ignore[operator]
+        self._skytraq_rec["last_packet"].value = raw  # type: ignore[assignment]
 
         if nav_data.fix_mode == FixMode.NO_FIX.value:
-            skytraq_rec["fix_mode"].value = FixMode.NO_FIX.value
+            self._skytraq_rec["fix_mode"].value = FixMode.NO_FIX.value
         else:
             # GPS time is weeks and seconds since midnight 1980-1-6 (with the skytraq tow field
             # being centiseconds, see AN0037 Navigation Data Message), except that UTC suffers from
@@ -88,21 +92,21 @@ class GpsService(Service):
             )
 
             # sync clock if it hasn't been syncd yet
-            if not self.is_syncd_obj.value and geteuid() == 0:
+            if not self._is_syncd.value and geteuid() == 0:
                 clock_settime(CLOCK_REALTIME, dt.timestamp())
                 logger.info("set time based off of skytraq time")
-                self.is_syncd_obj.value = True
+                self._is_syncd.value = True
 
             # add all skytraq data to OD
             for key, value in nav_data._asdict().items():
                 if key == "message_id":
                     continue
-                skytraq_rec[key].value = value
+                self._skytraq_rec[key].value = value
 
             ms_since_midnight = (((((dt.hour * 60) + dt.minute) * 60) + dt.second) * 1000) + (
                 dt.microsecond // 1000
             )
-            skytraq_rec["time_since_midnight"].value = ms_since_midnight
+            self._skytraq_rec["time_since_midnight"].value = ms_since_midnight
 
             # send gps tpdos
             try:
@@ -119,7 +123,7 @@ class GpsService(Service):
         else:
             self._state = GpsState.SEARCHING
 
-    def on_loop_error(self, error: str) -> None:
+    def on_loop_error(self, error: Exception) -> None:
         self._skytraq_power_off()
         self._state = GpsState.ERROR
         logger.exception(error)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Topic :: Software Development :: Embedded Systems",
 ]
 dependencies = [
-    "oresat-olaf>=3.6.5",
+    "oresat-olaf>=3.7.0",
     "pyserial",
     "gpiod",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ ignore = [
     "EM102", # Exception must not use an f-string literal
     "FIX",  # flake8-fixme
     "TD",  # flake8-todos
+    "TC006", # Add quotes to type expression in `typing.cast()`
     # This might be good to turn on later, right now I'm on the fence about it
     "TRY003",  # Avoid specifying long messages outside the exception class
     # Another one that might be good later but for now is too argessive. Many of


### PR DESCRIPTION
Trusted publishing is the new more secure way of uploading packages to pypi. See https://docs.pypi.org/trusted-publishers/

This also updates olaf to the latest version which will also pull in the latest oresat-configs.