### PR TITLE
Bump OLAF to 3.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Topic :: Software Development :: Embedded Systems",
 ]
 dependencies = [
-    "oresat-olaf>=3.7.0",
+    "oresat-olaf>=3.7.1",
     "pyserial",
     "gpiod",
 ]


### PR DESCRIPTION
This fixes a crash on startup trying to set the board number incorrectly