### PR TITLE
fix: binary mode not ACK'd when NMEA messages clog the buffer

### DIFF
--- a/oresat_gps/gps_service.py
+++ b/oresat_gps/gps_service.py
@@ -133,7 +133,7 @@ class GpsService(Service):
         try:
             self._skytraq.connect()
         except SkyTraqError as e:
-            logger.error("Error connecting to SkyTraq: %s", e)
+            logger.exception(f"Error connecting to SkyTraq: {e}")
             self._skytraq.disconnect()
             return
         self._state = GpsState.SEARCHING

--- a/oresat_gps/skytraq.py
+++ b/oresat_gps/skytraq.py
@@ -121,7 +121,11 @@ class SkyTraq:
             Incorrect or missing ACK or NACK
         """
         for _ in range(read_count):
-            raw = self._read()
+            try:
+                raw = self._read()
+            except SkyTraqError:
+                logger.error(f"Error reading ACK: {e}")
+                continue
             csum = raw[-1]
             payload = raw[:-1]
             if csum != self.checksum(payload):
@@ -129,10 +133,10 @@ class SkyTraq:
             msg_id = payload[0]
             if msg_id == self.MSG_ID_ACK:
                 if payload[1] != expected_msg_id:
-                    raise SkyTraqError("ACK for wrong message: {payload[1]:#x")
+                    raise SkyTraqError(f"ACK for wrong message: {payload[1]:#x}")
                 return True
             if msg_id == self.MSG_ID_NACK:
-                logger.warning("NACK for %#x", expected_msg_id)
+                logger.warning(f"NACK for {expected_msg_id:#x}")
                 return False
         raise SkyTraqError("No ACK or NACK received")
 
@@ -244,7 +248,12 @@ class SkyTraq:
         """
         self._ser = Serial(str(self._port), self.BAUD, timeout=1)
         # swap to binary mode
-        self._ser.write(SkyTraq.encode_binary(0x09, b"\x02\x00"))
+        # for mysterious reasons this only seems to work by clearing the buffer,
+        # sending it, waiting, and then doing that a second time
+        for _ in range(2):
+            self._ser.read(self._ser.in_waiting)
+            self._ser.write(SkyTraq.encode_binary(0x09, b"\x02\x00"))
+            sleep(0.1)
         if not self._check_for_ack(0x09):
             logger.error("No ACK for Binary mode")
             raise SkyTraqError("Binary mode not acknowledged")

--- a/oresat_gps/skytraq.py
+++ b/oresat_gps/skytraq.py
@@ -123,7 +123,7 @@ class SkyTraq:
         for _ in range(read_count):
             try:
                 raw = self._read()
-            except SkyTraqError:
+            except SkyTraqError as e:
                 logger.error(f"Error reading ACK: {e}")
                 continue
             csum = raw[-1]


### PR DESCRIPTION
It's a hack, but it works. Also fix some debug messages.

For whatever mysterious reasons, binary mode only seems to go through, with ACK and clearing NMEA messages by looping twice through:

1. Clear the buffer
2. Send a binary mode message
3. wait 100ms

Amazing.